### PR TITLE
remove sqrt from l2_dist

### DIFF
--- a/vae.py
+++ b/vae.py
@@ -26,7 +26,7 @@ def loss_function(recon_x, x, mu, logvar):
     recon_x = recon_x.view(n, -1)
     x = x.view(n, -1)
     # L2 distance
-    l2_dist = torch.mean(torch.sqrt(torch.sum(torch.pow(recon_x - x, 2), 1)))
+    l2_dist = torch.mean(torch.sum(torch.pow(recon_x - x, 2), 1))
     # see Appendix B from VAE paper:
     # Kingma and Welling. Auto-Encoding Variational Bayes. ICLR, 2014
     # https://arxiv.org/abs/1312.6114


### PR DESCRIPTION
Nice project. I've been trying it out, and I noticed you have a sqrt in l2 dist, but you might want to try removing it. [L2 loss normally doesn't include it](http://www.chioka.in/differences-between-l1-and-l2-as-loss-function-and-regularization/), and other implementations of the world models paper don't include it. I think the consequence of including the sqrt, is that the KL component of the loss is comparatively large, which could prevent convergence. 

Maybe I'm missing something, but I thought I would point it out, just in case.